### PR TITLE
Add Protection Against Trampling of Farmland

### DIFF
--- a/src/events/CheckEvent.php
+++ b/src/events/CheckEvent.php
@@ -11,6 +11,7 @@ use pocketmine\event\block\BlockPlaceEvent;
 use pocketmine\event\entity\EntityDamageByEntityEvent;
 use pocketmine\event\entity\EntityDamageEvent;
 use pocketmine\event\entity\EntityExplodeEvent;
+use pocketmine\event\entity\EntityTrampleFarmlandEvent;
 use pocketmine\event\EventPriority;
 use pocketmine\event\Listener;
 use pocketmine\event\player\PlayerBedEnterEvent;
@@ -29,17 +30,20 @@ class CheckEvent implements Listener
 
     public function __construct() {}
 
-    public static function init(Main $plugin)
+    public static function init(Main $plugin): void
     {
-        $checkEvent = new CheckEvent();
-        $plugin->getServer()->getPluginManager()->registerEvent("pocketmine\\event\\player\\PlayerInteractEvent", Closure::fromCallable([$checkEvent, 'onInteractEvent']), EventPriority::LOWEST, $plugin);
-        $plugin->getServer()->getPluginManager()->registerEvent("pocketmine\\event\\player\\PlayerBedEnterEvent", Closure::fromCallable([$checkEvent, 'enterBedEvent']), EventPriority::LOWEST, $plugin);
-        $plugin->getServer()->getPluginManager()->registerEvent("pocketmine\\event\\block\\BlockBreakEvent", Closure::fromCallable([$checkEvent, 'onBreakEvent']), EventPriority::LOWEST, $plugin);
-        $plugin->getServer()->getPluginManager()->registerEvent("pocketmine\\event\\player\\PlayerDropItemEvent", Closure::fromCallable([$checkEvent, 'onDropEvent']), EventPriority::LOWEST, $plugin);
-        $plugin->getServer()->getPluginManager()->registerEvent("pocketmine\\event\\block\\BlockPlaceEvent", Closure::fromCallable([$checkEvent, 'onPlaceEvent']), EventPriority::LOWEST, $plugin);
-        $plugin->getServer()->getPluginManager()->registerEvent("pocketmine\\event\\entity\\EntityDamageEvent", Closure::fromCallable([$checkEvent, 'onPvpEvent']), EventPriority::LOWEST, $plugin);
-        $plugin->getServer()->getPluginManager()->registerEvent("pocketmine\\event\\player\\PlayerMoveEvent", Closure::fromCallable([$checkEvent, 'onFlyEvent']), EventPriority::LOWEST, $plugin);
-        $plugin->getServer()->getPluginManager()->registerEvent("pocketmine\\event\\entity\\EntityExplodeEvent", Closure::fromCallable([$checkEvent, 'onExplodeEvent']), EventPriority::LOWEST, $plugin);
+        $eventHandler = new CheckEvent();
+        $pluginManager = $plugin->getServer()->getPluginManager();
+
+        $pluginManager->registerEvent(PlayerInteractEvent::class, Closure::fromCallable([$eventHandler, 'onInteract']), EventPriority::LOWEST, $plugin);
+        $pluginManager->registerEvent(PlayerBedEnterEvent::class, Closure::fromCallable([$eventHandler, 'onBedEnter']), EventPriority::LOWEST, $plugin);
+        $pluginManager->registerEvent(BlockBreakEvent::class, Closure::fromCallable([$eventHandler, 'onBlockBreak']), EventPriority::LOWEST, $plugin);
+        $pluginManager->registerEvent(PlayerDropItemEvent::class, Closure::fromCallable([$eventHandler, 'onItemDrop']), EventPriority::LOWEST, $plugin);
+        $pluginManager->registerEvent(BlockPlaceEvent::class, Closure::fromCallable([$eventHandler, 'onBlockPlace']), EventPriority::LOWEST, $plugin);
+        $pluginManager->registerEvent(EntityDamageEvent::class, Closure::fromCallable([$eventHandler, 'onEntityDamage']), EventPriority::LOWEST, $plugin);
+        $pluginManager->registerEvent(PlayerMoveEvent::class, Closure::fromCallable([$eventHandler, 'onPlayerMove']), EventPriority::LOWEST, $plugin);
+        $pluginManager->registerEvent(EntityExplodeEvent::class, Closure::fromCallable([$eventHandler, 'onEntityExplode']), EventPriority::LOWEST, $plugin);
+        $pluginManager->registerEvent(EntityTrampleFarmlandEvent::class, Closure::fromCallable([$eventHandler, 'onTrampleFarmland']), EventPriority::LOWEST, $plugin);
     }
 
     public function onPlaceEvent(BlockPlaceEvent $event)
@@ -205,6 +209,28 @@ class CheckEvent implements Listener
                         return;
                     }
                 }
+            }
+        }
+    }
+
+    public function onEntityTrampleFarmland(EntityTrampleFarmlandEvent $event): void
+    {
+        $entity = $event->getEntity();
+        $pos = $event->getBlock()->getPosition();
+        $landManager = new LandManager();
+        $landsInArea = $landManager->getLandsIn($pos);
+
+        foreach ($landsInArea as $landId => $landData) {
+            if ($entity instanceof Player) {
+                if ($landData['owner'] !== $entity->getName()) {
+                    if (!$entity->hasPermission("claimandprotect.bypass")) {
+                        $event->cancel();
+                        return;
+                    }
+                }
+            } else {
+                $event->cancel();
+                return;
             }
         }
     }


### PR DESCRIPTION
This Pull Request introduces a handler for the `EntityTrampleFarmlandEvent` to prevent unauthorized players or entities from trampling farmland in protected land areas.  

### Key Changes:  
- Implemented `EntityTrampleFarmlandEvent` to:  
  - Cancel the event if the farmland is within a claimed area.  
  - Check if the entity causing the trampling has the appropriate permissions or ownership.  

### Benefits:  
- Ensures farmland within protected areas is safe from accidental or intentional damage.  
- Improves overall land protection functionality by addressing entity-related interactions.  
